### PR TITLE
fix: ensure that isLocked save string and load number

### DIFF
--- a/src/isLocked.js
+++ b/src/isLocked.js
@@ -9,13 +9,13 @@ module.exports = function (filename) {
   let running;
   try {
     const pid = fs.readFileSync(filename, 'utf8');
-    running = isRunning(pid);
+    running = pid && isRunning(Number(pid));
     if (!running) {
-      fs.writeFileSync(filename, process.pid);
+      fs.writeFileSync(filename, String(process.pid));
     }
   } catch (e) {
     if (e.code === 'ENOENT') {
-      fs.writeFileSync(filename, process.pid);
+      fs.writeFileSync(filename, String(process.pid));
       running = false;
     } else {
       throw e;


### PR DESCRIPTION
There was a bug on `de` that prevented the build because we try to writeFileSync a number.

This fix ensure that we write a string and that if a previous file exists we convert the text to number.

No test cases so I never feel confident to merge this PR ...